### PR TITLE
Add jest timer cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ To continually run tests as files change, use watch mode:
 npm run test:watch
 ```
 
+If you enable fake timers in a test with `jest.useFakeTimers()`, be sure to
+reset them afterwards:
+
+```ts
+afterEach(() => {
+  jest.useRealTimers();
+});
+```
+
 ## SEO
 
 SEO metadata is defined in [`src/meta/index.js`](src/meta/index.js).

--- a/__tests__/Sliders.test.jsx
+++ b/__tests__/Sliders.test.jsx
@@ -20,6 +20,9 @@ jest.mock('swiper/css/navigation', () => ({}))
 jest.mock('swiper/css/pagination', () => ({}))
 
 describe('Slider slides navigation', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
   test('artist slide navigates on click', () => {
     const navigate = jest.fn()
     useNavigate.mockReturnValue(navigate)

--- a/__tests__/generateStaticParams.test.ts
+++ b/__tests__/generateStaticParams.test.ts
@@ -14,6 +14,7 @@ describe('generateStaticParams', () => {
   afterEach(() => {
     process.env = originalEnv
     ;(global.fetch as unknown as jest.Mock).mockReset()
+    jest.useRealTimers()
   })
 
   test('returns params when API_BASE_URL is provided', async () => {

--- a/__tests__/getBaseUrl.test.ts
+++ b/__tests__/getBaseUrl.test.ts
@@ -10,6 +10,7 @@ describe('getBaseUrl', () => {
   afterEach(() => {
     delete (global as any).window
     delete process.env.API_BASE_URL
+    jest.useRealTimers()
   })
 
   describe('browser scenario', () => {

--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -11,6 +11,10 @@ describe('helper utilities', () => {
     process.env.API_BASE_URL = 'http://localhost:5000';
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('getImageUrl', () => {
     test('returns default image when no path provided', () => {
       expect(getImageUrl()).toBe('/img/placeholder.jpg');

--- a/__tests__/sanitizer.test.ts
+++ b/__tests__/sanitizer.test.ts
@@ -4,6 +4,10 @@ const window = new JSDOM('').window
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DOMPurify = createDOMPurify(window as any)
 
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 /** Basic sanitization check */
 test('unsafe HTML is sanitized', () => {
   const dirty = '<img src=x onerror=alert(1)><script>alert(1)</script><p>hi</p>'

--- a/__tests__/ssr.test.js
+++ b/__tests__/ssr.test.js
@@ -1,6 +1,10 @@
 import { getRandomNewsProps } from '../src/utils/serverProps.js'
 import { newsList } from '../src/data/news.js'
 
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 test('getServerSideProps returns a news item and timestamp', async () => {
   const { props } = await getRandomNewsProps()
   expect(props.randomNews).toBeDefined()


### PR DESCRIPTION
## Summary
- ensure all tests restore real timers after each run
- mention fake timers best practice in testing docs

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684766a91134832388b59bbdf74458f3