### PR TITLE
Update jest config for asset mocking

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+export default 'test-file-stub';

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
         '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+        '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/fileMock.js',
     },
 
     // Які розширення обробляти
@@ -20,6 +21,7 @@ const config: Config = {
     transform: {
         '^.+\\.(ts|tsx)$': 'ts-jest',
         '^.+\\.mjs$': 'babel-jest',
+        '\\.[jt]sx?$': 'babel-jest',
     },
 
     // Які шляхи ігнорувати при тестах


### PR DESCRIPTION
## Summary
- configure Jest to transform js/ts files with babel-jest
- map image imports to a file mock
- add a file mock under `__mocks__`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684915ddaaa0832395ccaf743b41f3ee