### PR TITLE
Configure Jest setup file

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,9 @@ const config: Config = {
     // Емуляція середовища браузера для SSR (jsdom)
     testEnvironment: 'jsdom',
 
+    // Setup files for custom matchers and other utilities
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
+
     // Мапінг псевдоніма @/
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
## Summary
- initialize Jest matchers via setupFilesAfterEnv

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684915e315748323a695a916aa795450