### PR TITLE
Fix Babel and Jest configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [
     "next/babel",
+    "@babel/preset-env",
     "@babel/preset-react"
   ],
   "plugins": []

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'jest'
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  extensionsToTreatAsEsm: ['.ts', '.tsx', '.js', '.jsx'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx', '.jsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
@@ -16,7 +16,7 @@ const config: Config = {
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.next/', '/dist/'],
-  transformIgnorePatterns: ['/node_modules/(?!(some-esm-package)/)'],
+  transformIgnorePatterns: ['/node_modules/'],
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",
     "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5",
     "eslint": "^8.46.0",
     "eslint-config-next": "^15.3.2",
     "eslint-import-resolver-typescript": "^4.4.3",


### PR DESCRIPTION
## Summary
- add Babel preset dependencies
- update .babelrc to use preset-env and preset-react
- adjust Jest config for proper transform settings

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68491f1575c48323923eee56e9cc518a