### PR TITLE
Document required Node 18 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This project uses **Next.js** for server-side rendering (SSR).
 
-The codebase is tested with **Node.js 18**. Run `nvm use` in the project
-directory to switch to this version. A `.nvmrc` file is included for
-convenience.
+This project requires **Node.js 18**. Run `nvm use` in the project
+directory to switch to this version. The `.nvmrc` file and the
+`package.json` `engines` field enforce this requirement.
 
 ## Getting Started
 
-This project requires Node 18 or later. Install dependencies and create a local `.env` file based on `.env.sample`:
+After switching to Node 18, install dependencies and create a local `.env` file based on `.env.sample`:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- clarify that Node 18 is mandatory
- update getting started instructions to switch Node versions first

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684951ff653483238c8473af6c31b6f7