### PR TITLE
Fix Jest config and add ts-node dev dependency

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,10 +1,11 @@
-iimport type { Config } from 'jest'
+import 'ts-node/register'
+import type { Config } from 'jest'
 
 const config: Config = {
     transform: {
         '^.+\\.[tj]sx?$': 'babel-jest',
     },
-    extensionsToTreatAsEsm: ['.ts', 'tsx', 'jsx'],
+    extensionsToTreatAsEsm: ['.ts', '.tsx', '.jsx'],
     setupFiles: ['<rootDir>/jest.setup.cjs'],
     testEnvironment: 'jsdom',
     moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^24.0.0",
     "next-sitemap": "^4.2.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
## Summary
- install ts-node dev dependency in package.json
- fix import typo in Jest config and ensure ESM extensions have dots
- register ts-node within jest.config.ts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495b467888832391eaf401b89a6dc9