### PR TITLE
Fix environment checks and build configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm install

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,7 @@ import path from 'path';
 const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
 
 if (process.env.NODE_ENV === 'production' && !process.env.NEXT_PUBLIC_API_BASE_URL) {
-  throw new Error('Missing NEXT_PUBLIC_API_BASE_URL for production build');
+  console.warn('NEXT_PUBLIC_API_BASE_URL is not defined, defaulting to http://localhost:3000');
 }
 
 /** @type {import('next').NextConfig} */

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import './styles/index.scss'
 // Use a relative import so the module system works correctly when
 // this file is used outside of a Node.js environment with absolute
 // path resolution.
-import App from './assets/screens/home/Home.jsx'
+import App from './App.jsx'
 
 const container = document.getElementById('root')
 const root = createRoot(container)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 const envSchema = z.object({
-  NEXT_PUBLIC_API_BASE_URL: z.string().nonempty(),
+  NEXT_PUBLIC_API_BASE_URL: z.string().optional(),
   API_BASE_URL: z.string().optional(),
   NEXT_PUBLIC_GA_ID: z.string().optional(),
   NEXTAUTH_SECRET: z.string(),


### PR DESCRIPTION
## Summary
- use Node 20 in Dockerfile
- allow NEXT_PUBLIC_API_BASE_URL to be optional
- warn if NEXT_PUBLIC_API_BASE_URL is missing during production build
- fix wrong import path in `src/index.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9af0f49c8323b2c5890dc8b9d962