### PR TITLE
Fix Quill versions for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,17 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.5.2",
     "react-leaflet": "^4.2.1",
-    "react-quill": "^2.0.0",
+    "react-quill": "^1.3.5",
+    "quill": "^1.3.7",
     "react-router-dom": "^7.6.2",
     "react-toastify": "^11.0.5",
     "sass": "^1.89.1",
     "swiper": "^11.2.8",
     "zod": "^3.22.4"
+  },
+  "overrides": {
+    "react-quill": "^1.3.5",
+    "quill": "^1.3.7"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^15.3.3",
@@ -67,6 +72,7 @@
     "next-sitemap": "^4.2.3",
     "typescript": "^5.8.3",
     "@types/react-quill": "^2.0.8",
-    "@types/leaflet": "^1.9.7"
+    "@types/leaflet": "^1.9.7",
+    "@types/quill": "^1.3.10"
   }
 }


### PR DESCRIPTION
## Summary
- use React-Quill v1 and Quill v1 for React 18 compatibility
- add `@types/quill`
- pin compatible versions via `overrides`

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc0aff998832389cf9b549d468bc6