### PR TITLE
Fix NextAuth App Router route

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,17 +1,5 @@
 import NextAuth from 'next-auth'
-import GitHubProvider from 'next-auth/providers/github'
-import type { NextAuthOptions } from 'next-auth'
-import { env } from '@/utils/env'
-
-export const authOptions: NextAuthOptions = {
-  providers: [
-    GitHubProvider({
-      clientId: env.GITHUB_ID,
-      clientSecret: env.GITHUB_SECRET,
-    }),
-  ],
-  secret: env.NEXTAUTH_SECRET,
-}
+import { authOptions } from '@/lib/auth'
 
 const handler = NextAuth(authOptions)
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,13 @@
+import GitHubProvider from 'next-auth/providers/github'
+import type { NextAuthOptions } from 'next-auth'
+import { env } from '@/utils/env'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GitHubProvider({
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
+    }),
+  ],
+  secret: env.NEXTAUTH_SECRET,
+}


### PR DESCRIPTION
## Summary
- move `authOptions` to `src/lib/auth.ts`
- refactor `[...nextauth]` API route to use named exports

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccff7a9a883239f9842c72ba1fc95