### PR TITLE
Fix TypeScript error re-exporting error component

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,2 +1,2 @@
 "use client";
-export { default } from '../error'
+export { default } from '../error.tsx'


### PR DESCRIPTION
## Summary
- add explicit file extension when re-exporting the global error page from `[locale]/error.tsx`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd54bc4d48323a2203c17838a2ca1