### PR TITLE
Fix absolute import for locale-specific error

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,2 +1,2 @@
 "use client";
-export { default } from '../error.tsx'
+export { default } from '@/app/error';


### PR DESCRIPTION
## Summary
- update dynamic locale error boundary import to use absolute path

## Testing
- `npm install --legacy-peer-deps` *(fails: registry.npmjs.org blocked)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cda00fa088323b5158fa9b46ae34a