### PR TITLE
Fix error boundary component directives

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,1 +1,2 @@
+"use client";
 export { default } from '../error.tsx';

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import Link from 'next/link'
 


### PR DESCRIPTION
## Summary
- mark all error boundary components in `src/app` as client components with `"use client"`

## Testing
- `npm install --legacy-peer-deps` *(fails: unable to reach registry)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdda3cf488323945d5e24fb511ab4