### PR TITLE
Enable TS extensions for module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "./src/types"
     ],
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- allow TypeScript import paths that end in `.ts` or `.tsx`

## Testing
- `npm install --legacy-peer-deps` *(fails: network access blocked)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d277108b4832393c163fcb1203082