### PR TITLE
Relax Node engine and set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test --if-present

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=false

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This project uses **Next.js** for server-side rendering (SSR).
 
-This project requires **Node.js 18 LTS**. After cloning, run `nvm use` in the
-project directory to switch to this version. The `.nvmrc` file and the
-`package.json` `engines` field enforce this requirement.
+This project prefers **Node.js 18 LTS** but also supports Node.js 19 and 20.
+After cloning, run `nvm use` in the project directory to switch to the
+recommended version. The `.nvmrc` file sets Node 18 by default and the
+`package.json` `engines` field allows any Node.js version >=18 and <21.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18 <19"
+    "node": ">=18 <21"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- allow Node >=18 and <21
- document Node 18-20 support in the README
- disable strict engine checks via `.npmrc`
- add GitHub Actions workflow using Node 18

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684db36560c48323a7a41d2bbb393524