### PR TITLE
Resolve ReactQuill conflict and define update policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ This directory contains guides and reference material for working with the proje
 
 - **GCP_DEPLOYMENT.md** – instructions for building the Docker image and deploying the application to Google Cloud Run.
 - **SAMPLE_DATA.md** – example JSON data used in tests and local development.
+- **UPDATE_POLICY.md** – guidelines for keeping dependencies and Node.js up to date.
 
 Use these documents to configure your environment and learn about deployment.

--- a/docs/UPDATE_POLICY.md
+++ b/docs/UPDATE_POLICY.md
@@ -1,0 +1,14 @@
+# Dependency and Environment Update Policy
+
+This project relies on several key tools and frameworks. To keep the codebase stable we periodically review and update dependencies.
+
+## Schedule
+- **Quarterly audit** – run `npm outdated` every three months and plan upgrades for major packages.
+- **Security patches** – apply as soon as possible after notification.
+
+## Key Versions
+- **Node.js** – locked to version 18.x via `.nvmrc` and the `engines` field in `package.json`.
+- **React & Next.js** – upgrade only after verifying compatibility with all libraries.
+- **Other dependencies** – follow semantic versioning; prefer minor/patch upgrades.
+
+When a major release of React, Next.js or Node.js becomes available, create a dedicated branch to test the upgrade and update this document with any new requirements.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18 <19"
+    "node": "18.x"
   },
   "scripts": {
     "dev": "next dev",
@@ -33,17 +33,12 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^15.5.2",
     "react-leaflet": "^4.2.1",
-    "react-quill": "^1.3.5",
-    "quill": "^1.3.7",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^7.6.2",
     "react-toastify": "^11.0.5",
     "sass": "^1.89.1",
     "swiper": "^11.2.8",
     "zod": "^3.22.4"
-  },
-  "overrides": {
-    "react-quill": "^1.3.5",
-    "quill": "^1.3.7"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^15.3.3",

--- a/src/types/react-quill.d.ts
+++ b/src/types/react-quill.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-quill';


### PR DESCRIPTION
## Summary
- update react-quill to version 2 and remove overrides
- lock Node.js to the 18.x series
- document dependency update policy
- remove obsolete local react-quill type stub

## Testing
- `npx tsc --noEmit` *(fails: Cannot parse src/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684db63ca7d08323b981b3f3268b3cad