### PR TITLE
Fix LayoutProps type in locale layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,8 +1,10 @@
-import type { LayoutProps } from 'next'
+import type { LayoutProps } from '@/types/layout'
 
-export default function LocaleLayout(
-  { children, params }: LayoutProps<{ locale: string }>
-) {
+export type LocaleLayoutProps = LayoutProps<{
+  locale: string
+}>
+
+export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
   return (
     <html lang={params.locale}>
       <body>{children}</body>

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+
+export type LayoutProps<T = {}> = {
+  children: ReactNode
+  params: T
+}


### PR DESCRIPTION
## Summary
- add generic `LayoutProps` type for app layouts
- use new type in `[locale]` layout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db7fac58483239d7950b1ab3b8cda